### PR TITLE
Resolve CVE-2024-39908 and SASS warning

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,17 +12,17 @@ GEM
   remote: https://rubygems.org/
   specs:
     Ascii85 (1.1.1)
-    addressable (2.8.6)
-      public_suffix (>= 2.0.2, < 6.0)
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
     afm (0.2.2)
-    async (2.12.0)
+    async (2.14.2)
       console (~> 1.25, >= 1.25.2)
       fiber-annotation
-      io-event (~> 1.6)
+      io-event (~> 1.6, >= 1.6.5)
     bigdecimal (3.1.8)
     colorator (1.1.0)
-    concurrent-ruby (1.3.1)
-    console (1.25.2)
+    concurrent-ruby (1.3.3)
+    console (1.27.0)
       fiber-annotation
       fiber-local (~> 1.1)
       json
@@ -32,22 +32,23 @@ GEM
     ethon (0.16.0)
       ffi (>= 1.15.0)
     eventmachine (1.2.7)
-    faraday (2.5.2)
-      faraday-net_http (>= 2.0, < 3.1)
-      ruby2_keywords (>= 0.0.4)
-    faraday-net_http (3.0.0)
+    faraday (2.10.0)
+      faraday-net_http (>= 2.0, < 3.2)
+      logger
+    faraday-net_http (3.1.0)
+      net-http
     fastimage (2.3.1)
     ffi (1.17.0-aarch64-linux-gnu)
     ffi (1.17.0-x86_64-linux-gnu)
     fiber-annotation (0.2.0)
     fiber-local (1.1.0)
       fiber-storage
-    fiber-storage (0.1.1)
+    fiber-storage (0.1.2)
     forwardable-extended (2.6.0)
-    google-protobuf (4.27.0-aarch64-linux)
+    google-protobuf (4.27.2-aarch64-linux)
       bigdecimal
       rake (>= 13)
-    google-protobuf (4.27.0-x86_64-linux)
+    google-protobuf (4.27.2-x86_64-linux)
       bigdecimal
       rake (>= 13)
     hashery (2.1.2)
@@ -63,7 +64,7 @@ GEM
     http_parser.rb (0.8.0)
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
-    io-event (1.6.0)
+    io-event (1.6.5)
     jekyll (4.3.3)
       addressable (~> 2.4)
       colorator (~> 1.0)
@@ -106,10 +107,13 @@ GEM
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
+    logger (1.6.0)
     mercenary (0.4.0)
-    nokogiri (1.16.5-aarch64-linux)
+    net-http (0.4.1)
+      uri
+    nokogiri (1.16.6-aarch64-linux)
       racc (~> 1.4)
-    nokogiri (1.16.5-x86_64-linux)
+    nokogiri (1.16.6-x86_64-linux)
       racc (~> 1.4)
     octokit (4.25.1)
       faraday (>= 1, < 3)
@@ -122,23 +126,22 @@ GEM
       hashery (~> 2.0)
       ruby-rc4
       ttfunk
-    public_suffix (5.0.5)
+    public_suffix (6.0.1)
     racc (1.8.0)
     rainbow (3.1.1)
     rake (13.2.1)
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rexml (3.2.8)
-      strscan (>= 3.0.9)
-    rouge (4.2.1)
+    rexml (3.3.2)
+      strscan
+    rouge (4.3.0)
     ruby-rc4 (0.1.5)
-    ruby2_keywords (0.0.5)
     safe_yaml (1.0.5)
-    sass-embedded (1.77.4-aarch64-linux-gnu)
-      google-protobuf (>= 3.25, < 5.0)
-    sass-embedded (1.77.4-x86_64-linux-gnu)
-      google-protobuf (>= 3.25, < 5.0)
+    sass-embedded (1.77.8-aarch64-linux-gnu)
+      google-protobuf (~> 4.26)
+    sass-embedded (1.77.8-x86_64-linux-gnu)
+      google-protobuf (~> 4.26)
     sawyer (0.9.2)
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
@@ -150,9 +153,10 @@ GEM
     typhoeus (1.4.1)
       ethon (>= 0.9.0)
     unicode-display_width (2.5.0)
+    uri (0.13.0)
     webrick (1.8.1)
     yell (2.2.2)
-    zeitwerk (2.6.15)
+    zeitwerk (2.6.16)
 
 PLATFORMS
   aarch64-linux
@@ -174,4 +178,4 @@ DEPENDENCIES
   webrick
 
 BUNDLED WITH
-   2.3.21
+   2.4.10

--- a/_sass/_details.scss
+++ b/_sass/_details.scss
@@ -14,12 +14,12 @@ details:not([open]) {
 
 
 details[open] summary {
+    // Only put border on top when open.
+    border-radius: $br $br 0 0;
+
     &::after {
         transform: rotate(-180deg);
     }
-
-    // Only put border on top when open.
-    border-radius: $br $br 0 0;
 }
 
 details {


### PR DESCRIPTION
- https://www.ruby-lang.org/en/news/2024/07/16/dos-rexml-cve-2024-39908/
- https://sass-lang.com/documentation/breaking-changes/mixed-decls/